### PR TITLE
Changed Hazelcast put calls to set for better performance

### DIFF
--- a/cache-hazelcast/src/main/java/io/micronaut/cache/hazelcast/HazelcastAsyncCache.java
+++ b/cache-hazelcast/src/main/java/io/micronaut/cache/hazelcast/HazelcastAsyncCache.java
@@ -132,9 +132,9 @@ public class HazelcastAsyncCache implements AsyncCache<IMap<Object, Object>> {
         ArgumentUtils.requireNonNull("key", key);
         ArgumentUtils.requireNonNull("value", value);
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        nativeCache.putAsync(key, value).andThen(new ExecutionCallback<Object>() {
+        nativeCache.setAsync(key, value).andThen(new ExecutionCallback<Void>() {
             @Override
-            public void onResponse(Object response) {
+            public void onResponse(Void response) {
                 future.complete(true);
             }
 

--- a/cache-hazelcast/src/main/java/io/micronaut/cache/hazelcast/HazelcastSyncCache.java
+++ b/cache-hazelcast/src/main/java/io/micronaut/cache/hazelcast/HazelcastSyncCache.java
@@ -86,7 +86,7 @@ public class HazelcastSyncCache implements SyncCache<IMap<Object, Object>> {
     public void put(@Nonnull Object key, @Nonnull Object value) {
         ArgumentUtils.requireNonNull("key", key);
         ArgumentUtils.requireNonNull("value", value);
-        nativeCache.put(key, value);
+        nativeCache.set(key, value);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
`IMap#put` and `IMap#putAsync` APIs await to return the value, but `IMap#set` and `IMap#setAsync` don't. Because of that, set APIs perform better. 

I replaced puts with sets since the return values are not needed.