### PR TITLE
Added Hazelcast declarative configuration files for classpath

### DIFF
--- a/cache-hazelcast/src/main/java/io/micronaut/cache/hazelcast/condition/HazelcastConfigResourceCondition.java
+++ b/cache-hazelcast/src/main/java/io/micronaut/cache/hazelcast/condition/HazelcastConfigResourceCondition.java
@@ -35,8 +35,10 @@ import java.util.stream.Stream;
  */
 public class HazelcastConfigResourceCondition implements Condition {
 
-    public static final String[] CLIENT_CONFIG_FILES = {"hazelcast-client.xml", "hazelcast-client.yml"};
-    public static final String[] INSTANCE_CONFIG_FILES = {"hazelcast.xml", "hazelcast.yml"};
+    public static final String[] CLIENT_CONFIG_FILES = {"hazelcast-client.xml", "hazelcast-client.yml",
+                                                        "classpath:hazelcast-client.xml", "classpath:hazelcast-client.yml"};
+    public static final String[] INSTANCE_CONFIG_FILES = {"hazelcast.xml", "hazelcast.yml", "classpath:hazelcast.xml",
+                                                          "classpath:hazelcast.yml"};
 
     @Override
     public boolean matches(ConditionContext context) {


### PR DESCRIPTION
Without adding these paths, it doesn't locate the configuration files located in the classpath.