### PR TITLE
Refactored call to context proceed into a separate method.

### DIFF
--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -482,8 +482,12 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         return cacheNames;
     }
 
+    protected Object doContextProceed(MethodInvocationContext context) {
+        return context.proceed();
+    }
+
     private void doProceed(MethodInvocationContext context, ValueWrapper wrapper) {
-        Object result = context.proceed();
+        Object result = doContextProceed(context);
         if (result instanceof Optional) {
             Optional optional = (Optional) result;
             wrapper.optional = true;


### PR DESCRIPTION
This PR exposes a new method (`doContextProceed`) which can be overridden. This allows sub-types of a `CacheInterceptor` to intercept calls to the user code.