### PR TITLE
Fix scenarios When Cache Write Operations Are Empty List

### DIFF
--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -328,7 +328,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                                                           CacheOperation cacheOperation,
                                                           CompletionStage<?> value) {
         List<AnnotationValue<CachePut>> putOperations = cacheOperation.putOperations;
-        if (putOperations != null) {
+        if (CollectionUtils.isNotEmpty(putOperations)) {
             for (AnnotationValue<CachePut> putOperation : putOperations) {
                 String[] cacheNames = cacheOperation.getCachePutNames(putOperation);
                 if (ArrayUtils.isNotEmpty(cacheNames)) {
@@ -352,7 +352,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                                                                  CacheOperation cacheOperation,
                                                                  CompletionStage<?> value) {
         List<AnnotationValue<CacheInvalidate>> invalidateOperations = cacheOperation.invalidateOperations;
-        if (invalidateOperations != null) {
+        if (CollectionUtils.isNotEmpty(invalidateOperations)) {
             for (AnnotationValue<CacheInvalidate> invalidateOperation : invalidateOperations) {
                 String[] cacheNames = cacheOperation.getCacheInvalidateNames(invalidateOperation);
                 if (ArrayUtils.isNotEmpty(cacheNames)) {

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -224,14 +224,14 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         }
 
         List<AnnotationValue<CachePut>> cachePuts = cacheOperation.putOperations;
-        if (cachePuts != null) {
+        if (CollectionUtils.isNotEmpty(cachePuts)) {
             for (AnnotationValue<CachePut> cachePut : cachePuts) {
                 processCachePut(context, wrapper, cachePut, cacheOperation);
             }
         }
 
         List<AnnotationValue<CacheInvalidate>> cacheInvalidates = cacheOperation.invalidateOperations;
-        if (cacheInvalidates != null) {
+        if (CollectionUtils.isNotEmpty(cacheInvalidates)) {
             for (AnnotationValue<CacheInvalidate> cacheInvalidate : cacheInvalidates) {
                 processCacheEvict(context, cacheOperation, cacheInvalidate);
             }
@@ -694,7 +694,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         }
 
         boolean hasWriteOperations() {
-            return putOperations != null || invalidateOperations != null;
+            return CollectionUtils.isNotEmpty(putOperations) || CollectionUtils.isNotEmpty(invalidateOperations);
         }
 
         String[] getCachePutNames(AnnotationValue<CachePut> cacheConfig) {


### PR DESCRIPTION
When using `@Cacheable` I noticed, that in some cases the `putOperations` or `invalidateOperations` is an empty list, so the method `hasWriteOperations` returns `true`, which is invalid.

https://github.com/micronaut-projects/micronaut-cache/blob/a702e4ed9b6247e0c5e7d15d6f2e3871127be3be/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java#L696-L698

Simple fix to handle empty list...