### PR TITLE
Do not use latest docker image for Infinispan

### DIFF
--- a/cache-infinispan/src/test/groovy/io/micronaut/cache/infinispan/InfinispanAsyncCacheSpec.groovy
+++ b/cache-infinispan/src/test/groovy/io/micronaut/cache/infinispan/InfinispanAsyncCacheSpec.groovy
@@ -29,7 +29,7 @@ import spock.lang.Shared
 class InfinispanAsyncCacheSpec extends AbstractAsyncCacheSpec {
 
     @Shared
-    GenericContainer infinispan = new GenericContainer("infinispan/server")
+    GenericContainer infinispan = new GenericContainer("infinispan/server:12.0.2.Final-1")
             .withExposedPorts(11222)
             .withEnv('USER', 'user')
             .withEnv('PASS', 'pass')

--- a/cache-infinispan/src/test/groovy/io/micronaut/cache/infinispan/InfinispanCacheInfoSpec.groovy
+++ b/cache-infinispan/src/test/groovy/io/micronaut/cache/infinispan/InfinispanCacheInfoSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 class InfinispanCacheInfoSpec extends Specification {
 
     @Shared
-    GenericContainer infinispan = new GenericContainer("infinispan/server")
+    GenericContainer infinispan = new GenericContainer("infinispan/server:12.0.2.Final-1")
             .withExposedPorts(11222)
             .withEnv('USER', 'user')
             .withEnv('PASS', 'pass')

--- a/cache-infinispan/src/test/groovy/io/micronaut/cache/infinispan/InfinispanSyncCacheSpec.groovy
+++ b/cache-infinispan/src/test/groovy/io/micronaut/cache/infinispan/InfinispanSyncCacheSpec.groovy
@@ -19,14 +19,15 @@ import io.micronaut.cache.tck.AbstractSyncCacheSpec
 import io.micronaut.context.ApplicationContext
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.spock.Testcontainers
+import spock.lang.Retry
 import spock.lang.Shared
 
 @Testcontainers
-@spock.lang.Retry
+@Retry
 class InfinispanSyncCacheSpec extends AbstractSyncCacheSpec {
 
     @Shared
-    GenericContainer infinispan = new GenericContainer("infinispan/server")
+    GenericContainer infinispan = new GenericContainer("infinispan/server:12.0.2.Final-1")
             .withExposedPorts(11222)
             .withEnv('USER', 'user')
             .withEnv('PASS', 'pass')


### PR DESCRIPTION
Currently we only support 12.0 so we need to use the same version for Testcontainers
