### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/cache-caffeine/src/main/resources/META-INF/native-image/io.micronaut.cache/micronaut-cache-caffeine/native-image.properties
+++ b/cache-caffeine/src/main/resources/META-INF/native-image/io.micronaut.cache/micronaut-cache-caffeine/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.cache.caffeine.metrics.$CaffeineCacheMetricsBinder$Definition

--- a/cache-core/src/main/resources/META-INF/native-image/io.micronaut.cache/micronaut-cache-core/native-image.properties
+++ b/cache-core/src/main/resources/META-INF/native-image/io.micronaut.cache/micronaut-cache-core/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.cache.jcache.$JCacheManager$Definition,io.micronaut.cache.jcache.metrics.$JCacheMetricsBinder$Definition


### PR DESCRIPTION
This PR fixes the following GraalVM warnings:

```
Warning: class initialization of class io.micronaut.cache.caffeine.metrics.$CaffeineCacheMetricsBinder$Definition failed with exception java.lang.NoClassDefFoundError: io/micrometer/core/instrument/MeterRegistry. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.cache.caffeine.metrics.$CaffeineCacheMetricsBinder$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.cache.jcache.$JCacheManager$Definition failed with exception java.lang.NoClassDefFoundError: javax/cache/Cache. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.cache.jcache.$JCacheManager$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.cache.jcache.metrics.$JCacheMetricsBinder$Definition failed with exception java.lang.NoClassDefFoundError: javax/cache/CacheManager. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.cache.jcache.metrics.$JCacheMetricsBinder$Definition to explicitly request delayed initialization of this class.
```