### PR TITLE
#183 Fix cache key generation for Kotlin suspend functions

### DIFF
--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -950,7 +950,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
 
         CacheOperation(ExecutableMethod<?, ?> method, boolean isVoid) {
             this.defaultKeyGenerator = resolveKeyGenerator(
-                    method.classValue(CacheConfig.class, MEMBER_KEY_GENERATOR).orElse(null)
+                    method.classValue(CacheConfig.class, MEMBER_KEY_GENERATOR).orElse(getDefaultKeyGenerator(method))
             );
             this.putOperations = isVoid ? null : putOperations(method);
             this.invalidateOperations = invalidateOperations(method);
@@ -965,6 +965,14 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                         LOG.warn("No cache names defined for invocation [{}]. Skipping cache read operations.", method);
                     }
                 }
+            }
+        }
+
+        private Class<? extends CacheKeyGenerator> getDefaultKeyGenerator(ExecutableMethod<?, ?> method) {
+            if (method.isSuspend()) {
+                return KotlinSuspendFunCacheKeyGenerator.class;
+            } else {
+                return DefaultCacheKeyGenerator.class;
             }
         }
 

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.cache.interceptor;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.Arrays;
+
+/**
+ * <p>An implementation of the {@link CacheKeyGenerator} which works exactly like {@link DefaultCacheKeyGenerator} but drops the last parameter.
+ * </p>
+ *
+ * @author Jacek Gajek
+ * @since 3.2.3
+ */
+@Introspected
+public class KotlinSuspendFunCacheKeyGenerator extends DefaultCacheKeyGenerator {
+
+    @Override
+    public Object generateKey(AnnotationMetadata annotationMetadata, Object... params) {
+        if (params == null || params.length == 0) {
+            return super.generateKey(annotationMetadata, params);
+        } else {
+            Object[] usableParams = Arrays.copyOfRange(params, 0, params.length - 1);
+            return super.generateKey(annotationMetadata, usableParams);
+        }
+    }
+}


### PR DESCRIPTION
#183

If a controller method is a kotlin suspend fun, then the last item in the vararg params array is some temporary object which changes on every call. Therefore, although maybe some data is stored in a cache, the cache is never read because the key is always different.