### PR TITLE
JCacheSyncCache constructor needs to be protected

### DIFF
--- a/cache-core/src/main/java/io/micronaut/cache/jcache/JCacheSyncCache.java
+++ b/cache-core/src/main/java/io/micronaut/cache/jcache/JCacheSyncCache.java
@@ -47,7 +47,7 @@ public class JCacheSyncCache implements SyncCache<Cache> {
      * @param conversionService The conversion service
      * @param ioExecutor The IO executor
      */
-    JCacheSyncCache(
+    protected JCacheSyncCache(
             @NonNull Cache<?, ?> nativeCache,
             ConversionService<?> conversionService,
             ExecutorService ioExecutor) {


### PR DESCRIPTION
So that it can be subclassed