### PR TITLE
Fix ehcacheVersion missing from the docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,3 +8,7 @@ repositories {
     mavenCentral()
     maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
+
+publishGuide {
+    properties.put("ehcacheVersion", libs.versions.managed.ehcache.get())
+}


### PR DESCRIPTION
The documentation used a version property from gradle.properties which was removed when we moved to the version catalog.

This puts it back into the docs