### PR TITLE
Switch to using version catalog import

### DIFF
--- a/cache-caffeine/build.gradle
+++ b/cache-caffeine/build.gradle
@@ -10,12 +10,12 @@ dependencies {
 
     implementation(libs.reactor.core)
 
-    testAnnotationProcessor(libs.micronaut.inject.java)
+    testAnnotationProcessor(mn.micronaut.inject.java)
 
     testImplementation(libs.logback.classic)
     testImplementation(libs.cache.ri.impl)
-    testImplementation(libs.micronaut.management)
-    testImplementation(libs.micronaut.http.client)
-    testImplementation(libs.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.management)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
     testImplementation("io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion")
 }

--- a/cache-core/build.gradle
+++ b/cache-core/build.gradle
@@ -3,20 +3,20 @@ plugins {
 }
 
 dependencies {
-    api(libs.micronaut.aop)
-    api(libs.micronaut.http)
-    api(libs.micronaut.inject)
-    api(libs.micronaut.runtime)
+    api(mn.micronaut.aop)
+    api(mn.micronaut.http)
+    api(mn.micronaut.inject)
+    api(mn.micronaut.runtime)
 
     compileOnly("io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion")
-    compileOnly(libs.micronaut.management)
+    compileOnly(mn.micronaut.management)
     compileOnly(libs.cache.api)
 
     implementation(libs.reactor.core)
 
     testImplementation(libs.logback.classic)
-    testImplementation(libs.micronaut.http.client)
-    testImplementation(libs.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.inject.groovy)
     testImplementation(libs.cache.api)
     testImplementation(libs.cache.ri.impl)
 }

--- a/cache-ehcache/build.gradle
+++ b/cache-ehcache/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     api(libs.managed.ehcache.clustered)
 
     testImplementation projects.cacheTck
-    testImplementation(libs.micronaut.http.client)
-    testImplementation(libs.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.inject.groovy)
     testImplementation(libs.reactor.core)
     testImplementation(libs.testcontainers.spock)
 }

--- a/cache-hazelcast/build.gradle
+++ b/cache-hazelcast/build.gradle
@@ -7,11 +7,11 @@ dependencies {
     api projects.cacheCore
     api(libs.managed.hazelcast)
 
-    testAnnotationProcessor(libs.micronaut.inject.java)
+    testAnnotationProcessor(mn.micronaut.inject.java)
 
     testImplementation(projects.cacheTck)
-    testImplementation(libs.micronaut.http.client)
-    testImplementation(libs.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.inject.groovy)
     testImplementation(libs.reactor.core)
     testImplementation(libs.testcontainers.spock)
 }

--- a/cache-infinispan/build.gradle
+++ b/cache-infinispan/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     api(libs.managed.infinispan.client.hotrod)
 
     testImplementation projects.cacheTck
-    testImplementation(libs.micronaut.http.client)
-    testImplementation(libs.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.inject.groovy)
     testImplementation(libs.reactor.core)
     testImplementation(libs.testcontainers.spock)
 }

--- a/cache-management/build.gradle
+++ b/cache-management/build.gradle
@@ -4,12 +4,12 @@ plugins {
 
 dependencies {
     api projects.cacheCore
-    api(libs.micronaut.management)
+    api(mn.micronaut.management)
 
     implementation(libs.reactor.core)
 
     testImplementation projects.cacheCaffeine
-    testImplementation(libs.micronaut.http.client)
-    testImplementation(libs.micronaut.http.server.netty)
-    testImplementation(libs.micronaut.management)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.management)
 }

--- a/cache-noop/build.gradle
+++ b/cache-noop/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     api projects.cacheCore
 
-    testImplementation(libs.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.inject.groovy)
 }

--- a/cache-tck/build.gradle
+++ b/cache-tck/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(libs.micronaut.inject.groovy)
+    compileOnly(mn.micronaut.inject.groovy)
 
     runtimeOnly 'cglib:cglib-nodep:3.3.0'
     runtimeOnly 'org.objenesis:objenesis:3.3'
@@ -17,5 +17,5 @@ dependencies {
     implementation(libs.reactor.core)
     implementation(libs.spock.core)
 
-    implementation(libs.micronaut.test.spock)
+    implementation(mn.micronaut.test.spock)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,18 +13,6 @@ managed-ehcache-clustered = { module = "org.ehcache:ehcache-clustered", version.
 managed-infinispan-client-hotrod = { module = "org.infinispan:infinispan-client-hotrod", version.ref = "managed-infinispan" }
 managed-infinispan-core = { module = "org.infinispan:infinispan-core", version.ref = "managed-infinispan" }
 
-# Micronaut
-micronaut-aop = { module = "io.micronaut:micronaut-aop" }
-micronaut-http = { module = "io.micronaut:micronaut-http" }
-micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
-micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }
-micronaut-inject = { module = "io.micronaut:micronaut-inject" }
-micronaut-inject-groovy = { module = "io.micronaut:micronaut-inject-groovy" }
-micronaut-inject-java = { module = "io.micronaut:micronaut-inject-java" }
-micronaut-management = { module = "io.micronaut:micronaut-management" }
-micronaut-runtime = { module = "io.micronaut:micronaut-runtime" }
-micronaut-test-spock = { module = "io.micronaut.test:micronaut-test-spock" }
-
 cache-api = { module = "javax.cache:cache-api" }
 cache-ri-impl = { module = "org.jsr107.ri:cache-ri-impl", version.ref = "cache-ri-impl" }
 logback-classic = { module = "ch.qos.logback:logback-classic" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,3 +22,13 @@ include 'cache-noop'
 include 'cache-tck'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+    }
+}
+micronautBuild {
+    importMicronautCatalog()
+}


### PR DESCRIPTION
Allows us to clean the micronaut dependencies from the libs.versions file