### PR TITLE
Tweak example in cache-abstraction.adoc

### DIFF
--- a/src/main/docs/guide/cache-abstraction.adoc
+++ b/src/main/docs/guide/cache-abstraction.adoc
@@ -37,7 +37,7 @@ Then configure one or many caches. For example with `application.yml`:
 micronaut:
     caches:
         my-cache:
-            maximumSize: 20
+            maximum-size: 20
 ----
 
 The above example will configure a cache called "my-cache" with a maximum size of 20.


### PR DESCRIPTION
Use kebab case to set cache maximum size in example. This is consistent with the related recommendation for kebab case in Naming Caches not much after this change in the doc.