### PR TITLE
Fix handleLoadError for async cache errors

### DIFF
--- a/cache-caffeine/src/test/groovy/io/micronaut/cache/HandleLoadErrorIssueSpec.groovy
+++ b/cache-caffeine/src/test/groovy/io/micronaut/cache/HandleLoadErrorIssueSpec.groovy
@@ -1,0 +1,102 @@
+package io.micronaut.cache
+
+import io.micronaut.cache.annotation.Cacheable
+import io.micronaut.cache.interceptor.ParametersKey
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.convert.ConversionService
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Function
+
+class HandleLoadErrorIssueSpec extends Specification {
+
+    void "check #type"() {
+        given: 'our cache'
+        ApplicationContext ctx = ApplicationContext.run(
+                'spec.name': 'HandleLoadErrorIssueSpec',
+                'spec.type': type,
+                'micronaut.caches.cache.initialCapacity':10,
+        )
+        def cacheManager = ctx.getBean(CacheManager)
+        def cache = cacheManager.getCache('cache')
+
+        and: 'a converter that throws an exception when converting poison to Long'
+        def triggered = new AtomicBoolean(false)
+
+        ctx.getBean(ConversionService).addConverter(Poison.class, Long.class, (Poison poison) -> {
+            triggered.set(true)
+            throw new RuntimeException("Poison!")
+        } as Function<Poison, Long>)
+
+        and: 'we add poison to the cache'
+        cache.put(ParametersKey.ZERO_ARG_KEY, new Poison())
+
+        when: 'we call the service'
+        def result = getter(ctx.getBean(MyService))
+
+        then: 'the converter was triggered'
+        triggered.get()
+
+        and: 'the original method is invoked'
+        result == 666L
+
+        cleanup:
+        cache.invalidateAll()
+        ctx.close()
+
+        where:
+        type    | getter
+        'sync'  | { MyService s -> s.test() }
+        'async' | { MyService s -> s.test().get() }
+    }
+
+    @Introspected
+    static class Poison implements Serializable {
+    }
+
+    static interface MyService<T> {
+
+        T test()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'HandleLoadErrorIssueSpec')
+    @Requires(property = 'spec.type', value = 'sync')
+    static class MySyncService implements MyService<Long> {
+
+        @Cacheable('cache')
+        Long test() {
+            666L
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'HandleLoadErrorIssueSpec')
+    @Requires(property = 'spec.type', value = 'async')
+    static class MyAsyncService implements MyService<CompletableFuture<Long>> {
+
+        @Cacheable('cache')
+        CompletableFuture<Long> test() {
+            CompletableFuture.supplyAsync { 666L }
+        }
+    }
+
+    @Primary
+    @Singleton
+    @Replaces(DefaultCacheErrorHandler)
+    @Requires(property = 'spec.name', value = 'HandleLoadErrorIssueSpec')
+    static class MyCacheErrorHandler implements CacheErrorHandler {
+
+        @Override
+        boolean handleLoadError(Cache<?> cache, Object key, RuntimeException e) {
+            false
+        }
+    }
+}

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -887,7 +887,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         return asyncCache
             .invalidate(key)
             .exceptionallyAsync(throwable ->
-                exceptionallyAsync(throwable,errorHandler.handleInvalidateError(asyncCache, key, asRuntimeException(throwable)), true)
+                exceptionallyAsync(throwable, errorHandler.handleInvalidateError(asyncCache, key, asRuntimeException(throwable)), true)
             );
     }
 

--- a/cache-core/src/test/groovy/io/micronaut/cache/jcache/HandleLoadErrorIssueSpec.groovy
+++ b/cache-core/src/test/groovy/io/micronaut/cache/jcache/HandleLoadErrorIssueSpec.groovy
@@ -1,0 +1,121 @@
+package io.micronaut.cache.jcache
+
+import io.micronaut.cache.Cache
+import io.micronaut.cache.CacheErrorHandler
+import io.micronaut.cache.DefaultCacheErrorHandler
+import io.micronaut.cache.annotation.Cacheable
+import io.micronaut.cache.interceptor.ParametersKey
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.convert.ConversionService
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import javax.cache.CacheManager
+import javax.cache.Caching
+import javax.cache.configuration.MutableConfiguration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Function
+
+class HandleLoadErrorIssueSpec extends Specification {
+
+    void "check #type"() {
+        given: 'our cache'
+        ApplicationContext ctx = ApplicationContext.run(
+                (JCacheManager.JCACHE_ENABLED): true,
+                'spec.name': 'HandleLoadErrorIssueSpec',
+                'spec.type': type
+        )
+        def cacheManager = ctx.getBean(CacheManager)
+        def cache = cacheManager.getCache('cache')
+
+        and: 'a converter that throws an exception when converting poison to Long'
+        def triggered = new AtomicBoolean(false)
+
+        ctx.getBean(ConversionService).addConverter(Poison.class, Long.class, (Poison poison) -> {
+            triggered.set(true)
+            throw new RuntimeException("Poison!")
+        } as Function<Poison, Long>)
+
+        and: 'we add poison to the cache'
+        cache.put(ParametersKey.ZERO_ARG_KEY, new Poison())
+
+        when: 'we call the service'
+        def result = getter(ctx.getBean(MyService))
+
+        then: 'the converter was triggered'
+        triggered.get()
+
+        and: 'the original method is invoked'
+        result == 666L
+
+        cleanup:
+        cacheManager.destroyCache('cache')
+        ctx.close()
+
+        where:
+        type    | getter
+        'sync'  | { MyService s -> s.test() }
+        'async' | { MyService s -> s.test().get() }
+    }
+
+    @Introspected
+    static class Poison implements Serializable {
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = "HandleLoadErrorIssueSpec")
+    static class CacheFactory {
+
+        @Singleton
+        CacheManager cacheManager() {
+            Caching.getCachingProvider().cacheManager.tap {
+                createCache('cache', new MutableConfiguration())
+            }
+        }
+    }
+
+    static interface MyService<T> {
+
+        T test()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'HandleLoadErrorIssueSpec')
+    @Requires(property = 'spec.type', value = 'sync')
+    static class MySyncService implements MyService<Long> {
+
+        @Cacheable('cache')
+        Long test() {
+            666L
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'HandleLoadErrorIssueSpec')
+    @Requires(property = 'spec.type', value = 'async')
+    static class MyAsyncService implements MyService<CompletableFuture<Long>> {
+
+        @Cacheable('cache')
+        CompletableFuture<Long> test() {
+            CompletableFuture.supplyAsync { 666L }
+        }
+    }
+
+    @Primary
+    @Singleton
+    @Replaces(DefaultCacheErrorHandler)
+    @Requires(property = 'spec.name', value = 'HandleLoadErrorIssueSpec')
+    static class MyCacheErrorHandler implements CacheErrorHandler {
+
+        @Override
+        boolean handleLoadError(Cache<?> cache, Object key, RuntimeException e) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
Closes #460

The fix is to change asyncCacheGet to use Optional.empty() as a default in case of exception, instead of null.

As part of this PR, I have also switched to use CompletableFuture.exceptionallyAsync which is from Java 12 instead of our own