### PR TITLE
#518 Fix suspend cache key: honor explicit params, drop hidden Continuation

### DIFF
--- a/cache-core/build.gradle
+++ b/cache-core/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     compileOnly(libs.cache.api)
 
     implementation(mn.reactor)
-    implementation(mn.kotlin.stdlib)
 
     testImplementation(mnLogging.logback.classic)
     testImplementation(mn.micronaut.http.client)

--- a/cache-core/build.gradle
+++ b/cache-core/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compileOnly(libs.cache.api)
 
     implementation(mn.reactor)
+    implementation(mn.kotlin.stdlib)
 
     testImplementation(mnLogging.logback.classic)
     testImplementation(mn.micronaut.http.client)

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -18,8 +18,10 @@ package io.micronaut.cache.interceptor;
 import io.micronaut.aop.InterceptPhase;
 import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.InvocationContext;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.aop.kotlin.KotlinInterceptedMethod;
 import io.micronaut.cache.AsyncCache;
 import io.micronaut.cache.AsyncCacheErrorHandler;
 import io.micronaut.cache.CacheErrorHandler;
@@ -50,6 +52,7 @@ import reactor.core.publisher.Mono;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -964,6 +967,9 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                 }
             }
             parameterValues = list.toArray();
+        }
+        if (InterceptedMethod.of(context, beanContext.getConversionService()) instanceof KotlinInterceptedMethod) {
+            parameterValues = Arrays.copyOf(parameterValues, parameterValues.length - 1);
         }
         return parameterValues;
     }

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -18,7 +18,6 @@ package io.micronaut.cache.interceptor;
 import io.micronaut.aop.InterceptPhase;
 import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.InterceptorBean;
-import io.micronaut.aop.InvocationContext;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.aop.kotlin.KotlinInterceptedMethod;
@@ -955,7 +954,11 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         Object[] parameterValues;
         Object[] methodParameterValues = context.getParameterValues();
         if (ArrayUtils.isEmpty(parameterNames)) {
-            parameterValues = methodParameterValues;
+            if (InterceptedMethod.of(context, beanContext.getConversionService()) instanceof KotlinInterceptedMethod) {
+                parameterValues = Arrays.copyOf(methodParameterValues, methodParameterValues.length - 1);
+            } else {
+                parameterValues = methodParameterValues;
+            }
         } else {
             List<Object> list = new ArrayList<>();
             Set<String> names = CollectionUtils.setOf(parameterNames);
@@ -967,9 +970,6 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                 }
             }
             parameterValues = list.toArray();
-        }
-        if (InterceptedMethod.of(context, beanContext.getConversionService()) instanceof KotlinInterceptedMethod) {
-            parameterValues = Arrays.copyOf(parameterValues, parameterValues.length - 1);
         }
         return parameterValues;
     }
@@ -1021,11 +1021,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         }
 
         private Class<? extends CacheKeyGenerator> getDefaultKeyGenerator(ExecutableMethod<?, ?> method) {
-            if (method.isSuspend()) {
-                return KotlinSuspendFunCacheKeyGenerator.class;
-            } else {
-                return DefaultCacheKeyGenerator.class;
-            }
+            return DefaultCacheKeyGenerator.class;
         }
 
         List<AnnotationValue<CachePut>> getPutOperations(MethodInvocationContext<?, ?> context) {

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
@@ -18,7 +18,8 @@ package io.micronaut.cache.interceptor;
 import io.micronaut.cache.annotation.Cacheable;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Introspected;
-import kotlin.coroutines.Continuation;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.KotlinUtils;
 
 import java.util.Arrays;
 
@@ -39,11 +40,17 @@ public class KotlinSuspendFunCacheKeyGenerator extends DefaultCacheKeyGenerator 
             return super.generateKey(metadata, params);
         }
 
-        // drop hidden Continuation if present as last argument
         int len = params.length;
         Object last = params[len - 1];
-        Object[] keyParams = (last instanceof Continuation) ? Arrays.copyOf(params, len - 1) : params;
 
+        boolean isContinuation = KotlinUtils.KOTLIN_COROUTINES_SUPPORTED
+            && ClassUtils.forName("kotlin.coroutines.Continuation", getClass().getClassLoader())
+            .map(contClass -> contClass.isInstance(last))
+            .orElse(false);
+
+        // drop hidden Continuation if present as last argument
+        Object[] keyParams = isContinuation ? Arrays.copyOf(params, len - 1) : params;
         return super.generateKey(metadata, keyParams);
     }
 }
+

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
@@ -15,11 +15,8 @@
  */
 package io.micronaut.cache.interceptor;
 
-import io.micronaut.cache.annotation.Cacheable;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.reflect.ClassUtils;
-import io.micronaut.core.util.KotlinUtils;
 
 import java.util.Arrays;
 
@@ -34,23 +31,12 @@ import java.util.Arrays;
 public class KotlinSuspendFunCacheKeyGenerator extends DefaultCacheKeyGenerator {
 
     @Override
-    public Object generateKey(AnnotationMetadata metadata, Object... params) {
-        String[] explicit = metadata.stringValues(Cacheable.class, "parameters");
-        if (params == null || params.length == 0 || explicit.length > 0) {
-            return super.generateKey(metadata, params);
+    public Object generateKey(AnnotationMetadata annotationMetadata, Object... params) {
+        if (params == null || params.length == 0) {
+            return super.generateKey(annotationMetadata, params);
+        } else {
+            Object[] usableParams = Arrays.copyOfRange(params, 0, params.length - 1);
+            return super.generateKey(annotationMetadata, usableParams);
         }
-
-        int len = params.length;
-        Object last = params[len - 1];
-
-        boolean isContinuation = KotlinUtils.KOTLIN_COROUTINES_SUPPORTED
-            && ClassUtils.forName("kotlin.coroutines.Continuation", getClass().getClassLoader())
-            .map(contClass -> contClass.isInstance(last))
-            .orElse(false);
-
-        // drop hidden Continuation if present as last argument
-        Object[] keyParams = isContinuation ? Arrays.copyOf(params, len - 1) : params;
-        return super.generateKey(metadata, keyParams);
     }
 }
-

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
@@ -26,7 +26,9 @@ import java.util.Arrays;
  *
  * @author Jacek Gajek
  * @since 3.2.3
+ * @deprecated Not used, the params are correctly calculated in {@link CacheInterceptor}
  */
+@Deprecated(forRemoval = true, since = "5.3.0")
 @Introspected
 public class KotlinSuspendFunCacheKeyGenerator extends DefaultCacheKeyGenerator {
 

--- a/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
+++ b/cache-core/src/main/java/io/micronaut/cache/interceptor/KotlinSuspendFunCacheKeyGenerator.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.cache.interceptor;
 
+import io.micronaut.cache.annotation.Cacheable;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Introspected;
+import kotlin.coroutines.Continuation;
 
 import java.util.Arrays;
 
@@ -31,12 +33,17 @@ import java.util.Arrays;
 public class KotlinSuspendFunCacheKeyGenerator extends DefaultCacheKeyGenerator {
 
     @Override
-    public Object generateKey(AnnotationMetadata annotationMetadata, Object... params) {
-        if (params == null || params.length == 0) {
-            return super.generateKey(annotationMetadata, params);
-        } else {
-            Object[] usableParams = Arrays.copyOfRange(params, 0, params.length - 1);
-            return super.generateKey(annotationMetadata, usableParams);
+    public Object generateKey(AnnotationMetadata metadata, Object... params) {
+        String[] explicit = metadata.stringValues(Cacheable.class, "parameters");
+        if (params == null || params.length == 0 || explicit.length > 0) {
+            return super.generateKey(metadata, params);
         }
+
+        // drop hidden Continuation if present as last argument
+        int len = params.length;
+        Object last = params[len - 1];
+        Object[] keyParams = (last instanceof Continuation) ? Arrays.copyOf(params, len - 1) : params;
+
+        return super.generateKey(metadata, keyParams);
     }
 }

--- a/test-suite-caffeine-kotlin/build.gradle.kts
+++ b/test-suite-caffeine-kotlin/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.kotlinx.coroutines.core)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnTest.micronaut.test.junit5)
 

--- a/test-suite-caffeine-kotlin/src/test/kotlin/io/micronaut/cache/SuspendCacheTest.kt
+++ b/test-suite-caffeine-kotlin/src/test/kotlin/io/micronaut/cache/SuspendCacheTest.kt
@@ -1,0 +1,88 @@
+package io.micronaut.cache
+
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.Cacheable
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@Singleton
+@CacheConfig(cacheNames = ["suspendedDefault"])
+open class DefaultSuspendService {
+
+    open var calls: Int = 0
+
+    @Cacheable
+    open suspend fun suspended(first: Int): Int {
+        calls++
+        return first
+    }
+}
+
+@Singleton
+@CacheConfig(cacheNames = ["suspended"])
+open class ExplicitSuspendService {
+
+    open var calls: Int = 0
+
+    @Cacheable(parameters = ["first"])
+    open suspend fun suspended(first: Int): Int {
+        calls++
+        return first
+    }
+}
+
+@MicronautTest
+internal class SuspendCacheTests {
+
+    @Inject
+    lateinit var defaultService: DefaultSuspendService
+
+    @Inject
+    lateinit var explicitService: ExplicitSuspendService
+
+    @Test
+    fun `caches all parameters for suspend function when none explicitly declared`() = runBlocking {
+        defaultService.calls = 0
+
+        // first call -> executes
+        assertEquals(1, defaultService.suspended(1))
+        assertEquals(1, defaultService.calls)
+
+        // same arg -> cached
+        assertEquals(1, defaultService.suspended(1))
+        assertEquals(1, defaultService.calls)
+
+        // new arg -> executes again
+        assertEquals(2, defaultService.suspended(2))
+        assertEquals(2, defaultService.calls)
+
+        // cached for second arg
+        assertEquals(2, defaultService.suspended(2))
+        assertEquals(2, defaultService.calls)
+    }
+
+    @Test
+    fun `caches only explicit parameters for suspend function`() = runBlocking {
+        explicitService.calls = 0
+
+        // first call with 1 -> executes
+        assertEquals(1, explicitService.suspended(1))
+        assertEquals(1, explicitService.calls)
+
+        // same arg -> cached
+        assertEquals(1, explicitService.suspended(1))
+        assertEquals(1, explicitService.calls)
+
+        // new arg 2 -> executes again
+        assertEquals(2, explicitService.suspended(2))
+        assertEquals(2, explicitService.calls)
+
+        // cached for second arg
+        assertEquals(2, explicitService.suspended(2))
+        assertEquals(2, explicitService.calls)
+    }
+}

--- a/test-suite-hazelcast-kotlin/build.gradle.kts
+++ b/test-suite-hazelcast-kotlin/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.kotlinx.coroutines.core)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnTest.micronaut.test.junit5)
     testImplementation(platform(mnTestResources.boms.testcontainers))

--- a/test-suite-hazelcast-kotlin/src/test/kotlin/io/micronaut/cache/SuspendCacheTest.kt
+++ b/test-suite-hazelcast-kotlin/src/test/kotlin/io/micronaut/cache/SuspendCacheTest.kt
@@ -1,0 +1,88 @@
+package io.micronaut.cache
+
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.Cacheable
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@Singleton
+@CacheConfig(cacheNames = ["suspendedDefault"])
+open class DefaultSuspendService {
+
+    open var calls: Int = 0
+
+    @Cacheable
+    open suspend fun suspended(first: Int): Int {
+        calls++
+        return first
+    }
+}
+
+@Singleton
+@CacheConfig(cacheNames = ["suspended"])
+open class ExplicitSuspendService {
+
+    open var calls: Int = 0
+
+    @Cacheable(parameters = ["first"])
+    open suspend fun suspended(first: Int): Int {
+        calls++
+        return first
+    }
+}
+
+@MicronautTest
+internal class SuspendCacheTests {
+
+    @Inject
+    lateinit var defaultService: DefaultSuspendService
+
+    @Inject
+    lateinit var explicitService: ExplicitSuspendService
+
+    @Test
+    fun `caches all parameters for suspend function when none explicitly declared`() = runBlocking {
+        defaultService.calls = 0
+
+        // first call -> executes
+        assertEquals(1, defaultService.suspended(1))
+        assertEquals(1, defaultService.calls)
+
+        // same arg -> cached
+        assertEquals(1, defaultService.suspended(1))
+        assertEquals(1, defaultService.calls)
+
+        // new arg -> executes again
+        assertEquals(2, defaultService.suspended(2))
+        assertEquals(2, defaultService.calls)
+
+        // cached for second arg
+        assertEquals(2, defaultService.suspended(2))
+        assertEquals(2, defaultService.calls)
+    }
+
+    @Test
+    fun `caches only explicit parameters for suspend function`() = runBlocking {
+        explicitService.calls = 0
+
+        // first call with 1 -> executes
+        assertEquals(1, explicitService.suspended(1))
+        assertEquals(1, explicitService.calls)
+
+        // same arg -> cached
+        assertEquals(1, explicitService.suspended(1))
+        assertEquals(1, explicitService.calls)
+
+        // new arg 2 -> executes again
+        assertEquals(2, explicitService.suspended(2))
+        assertEquals(2, explicitService.calls)
+
+        // cached for second arg
+        assertEquals(2, explicitService.suspended(2))
+        assertEquals(2, explicitService.calls)
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where cache key generator was always dropping the last argument of Kotlin `suspend` methods-even when you’d explicitly listed parameters in `@Cacheable`. Now:

* If you use `parameters = [...]`, we respect exactly those and don’t drop anything.
* Otherwise, we only strip out the hidden `Continuation` argument and include all your real parameters.

Added a several tests. Closes #518.

@graemerocher @dstepanov I'll glad to get your reviews
