### PR TITLE
Clarify cache behavior in reused test contexts

### DIFF
--- a/src/main/docs/guide/annotations.adoc
+++ b/src/main/docs/guide/annotations.adoc
@@ -6,6 +6,14 @@ The following cache annotations are supported:
 
 By using one of the annotations the api:cache.interceptor.CacheInterceptor[] is activated which in the case of `@Cacheable` will cache the return result of the method.
 
+[NOTE]
+.Cache hits skip method execution
+====
+When a value is already present for the computed cache key, `@Cacheable` returns the cached value and does not invoke the original method again.
+
+This also applies in tests that reuse the same application context. If multiple test methods use the same cache name and key, later tests may observe values cached by earlier tests unless the cache is invalidated or a different key is used.
+====
+
 If the return type of the method is a non-blocking type (either link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture] or an instance of rs:Publisher[] the emitted result will be cached.
 
 In addition if the underlying Cache implementation supports non-blocking cache operations then cache values will be read from the cache without blocking, resulting in the ability to implement completely non-blocking cache operations.

--- a/test-suite-caffeine-java/build.gradle.kts
+++ b/test-suite-caffeine-java/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation("org.mockito:mockito-core:5.20.0")
 
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(mnLogging.logback.classic)

--- a/test-suite-caffeine-java/src/test/java/io/micronaut/cache/MockBeanCacheableTest.java
+++ b/test-suite-caffeine-java/src/test/java/io/micronaut/cache/MockBeanCacheableTest.java
@@ -1,0 +1,66 @@
+package io.micronaut.cache;
+
+import io.micronaut.cache.annotation.CacheConfig;
+import io.micronaut.cache.annotation.Cacheable;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@MicronautTest(startApplication = false, transactional = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Requires(property = "spec.name", value = "MockBeanCacheableTest")
+class MockBeanCacheableTest {
+
+    @Inject
+    SomeClassWithCacheable someClass;
+
+    @Inject
+    SomeClassWithCacheable mockedSomeClass;
+
+    @Test
+    @Order(1)
+    void case1() {
+        reset(mockedSomeClass);
+        when(mockedSomeClass.test("shared-key")).thenReturn("case-1");
+
+        assertEquals("case-1", someClass.test("shared-key"));
+    }
+
+    @Test
+    @Order(2)
+    void case2() {
+        reset(mockedSomeClass);
+        when(mockedSomeClass.test("shared-key")).thenReturn("case-2");
+
+        assertEquals("case-1", someClass.test("shared-key"));
+        verifyNoInteractions(mockedSomeClass);
+    }
+
+    @MockBean(SomeClassWithCacheable.class)
+    SomeClassWithCacheable mockSomeClassWithCacheable() {
+        return mock(SomeClassWithCacheable.class);
+    }
+}
+
+@Singleton
+@Requires(property = "spec.name", value = "MockBeanCacheableTest")
+@CacheConfig(cacheNames = {"mock-bean-cacheable"})
+class SomeClassWithCacheable {
+
+    @Cacheable(parameters = {"param"})
+    String test(String param) {
+        return param;
+    }
+}


### PR DESCRIPTION
## Summary
- document that `@Cacheable` cache hits skip method execution and can persist across reused Micronaut test contexts
- add a Java `@MockBean` reproducer in the caffeine test suite for the reported behavior
- show that a cached value is returned before the replaced bean is invoked again when the same cache key is reused

## Verification
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java17 ./gradlew :test-suite-caffeine-java:test --tests '*CaffeineTest' --tests '*MockBeanCacheableTest'`

Resolves #10438