### PR TITLE
Fix vulnerability audit: jackson-core constraint and core 5.1.14 for netty

### DIFF
--- a/cache-infinispan/build.gradle
+++ b/cache-infinispan/build.gradle
@@ -7,6 +7,12 @@ dependencies {
 
     api(libs.managed.infinispan.core)
     api(libs.managed.infinispan.client.hotrod)
+    constraints {
+        // Infinispan 16.2.3 still uses protostream 6.0.9, which requests jackson-core 2.21.3 (GHSA-r7wm-3cxj-wff9)
+        api(libs.jackson.core) {
+            because("Require a non-vulnerable jackson-core version instead of the transitive version")
+        }
+    }
 
     testImplementation projects.micronautCacheTck
     testImplementation(mn.micronaut.http.client)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ micronaut-test-resources = "4.0.0"
 micronaut-validation = "5.1.0"
 graal-svm = "25.0.3"
 graal-plugin = "1.1.5"
+jackson-core = "2.22.2"
 
 [libraries]
 # Core
@@ -42,6 +43,7 @@ micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-
 
 cache-api = { module = "javax.cache:cache-api", version.ref = "cache-ri-impl" }
 cache-ri-impl = { module = "org.jsr107.ri:cache-ri-impl", version.ref = "cache-ri-impl" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson-core" }
 testcontainers-junit = { module = "org.testcontainers:testcontainers-junit-jupiter" }
 testcontainers-oracle = { module = "org.testcontainers:oracle-xe" }
 testcontainers-spock = { module = "org.testcontainers:testcontainers-spock" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "5.1.6"
+micronaut = "5.1.14"
 
 cache-ri-impl = "1.1.1"
 managed-caffeine = "3.2.4"


### PR DESCRIPTION
Fixes the `audit (25)` failure that blocks the core 5.2 bump in #1055, part of the core 5.2 rollout: micronaut-projects/micronaut-core#13110.

## Cause

```
- com.fasterxml.jackson.core:jackson-core:2.21.3 (GHSA-r7wm-3cxj-wff9; fixed: 2.18.8, 2.21.4, 3.1.4)
```

This is not introduced by #1055. The same finding fails the audit on every recent 6.2.x pull request (#1060, the common files sync, the svm update).

The path is only through `micronaut-cache-infinispan`:

```
micronaut-cache-infinispan -> infinispan-core / infinispan-client-hotrod 16.2.1
  -> infinispan-commons -> org.infinispan.protostream:protostream 6.0.9 -> jackson-core 2.21.3
```

Upgrading Infinispan does not help: 16.2.3 (#1060, the latest release) still uses protostream 6.0.9.

## Fix

Add `jackson-core` 2.22.2 to the version catalog and apply it as an `api` constraint in `cache-infinispan`, the same pattern micronaut-aws uses for its transitive jackson-core. It is not a `managed-` entry, so it does not end up in the cache BOM. Renovate will keep it current, and the constraint can be removed once Infinispan picks up a fixed protostream.

I didn't add an `osv-scanner.toml` exception: this is a runtime dependency of a published module and it can be upgraded.

## Verification

- `./gradlew :micronaut-cache-infinispan:dependencyInsight --dependency com.fasterxml.jackson.core --configuration runtimeClasspath`: `jackson-core:2.21.3 -> 2.22.2`
- `.github/scripts/vulnerability-audit.sh` on this branch plus the #1055 changes: `No known vulnerabilities found.`
- With only the jackson-core constraint, the audit on this PR still reported `io.netty:netty-handler:4.2.16.Final` (GHSA-c4c3-7fpv-j4q5, GHSA-fccg-mwvh-qqg4). The whole netty set (12 artifacts, through `netty-bom`) comes in through `infinispan-client-hotrod` and is managed by the Micronaut core BOM. Pinning netty-handler alone would split those versions, so this PR also moves core from 5.1.6 to 5.1.14. Its BOM already manages netty 4.2.17.Final, so the fix doesn't have to wait on #1055. #1055 changes the same catalog line and Renovate will rebase it.
- `.github/scripts/vulnerability-audit.sh` on this branch alone (jackson-core constraint and core 5.1.14): `No known vulnerabilities found.`
- `./gradlew testClasses :micronaut-cache-core:check :micronaut-cache-caffeine:check :micronaut-cache-infinispan:check`: passes (core 19, caffeine 17, infinispan 16 tests, 0 failures)
- `./gradlew :micronaut-cache-infinispan:check`: passes (16 tests, 0 failures; `checkPom` accepts the published constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
