### PR TITLE
Do not publish a strict jackson-core constraint from cache-infinispan

### DIFF
--- a/cache-infinispan/build.gradle
+++ b/cache-infinispan/build.gradle
@@ -10,9 +10,6 @@ dependencies {
 
     constraints {
         implementation('com.fasterxml.jackson.core:jackson-core:2.21.4') {
-            version {
-                strictly('2.21.4')
-            }
             because('2.21.3 is affected by GHSA-r7wm-3cxj-wff9')
         }
     }


### PR DESCRIPTION
Part of the core 5.2 rollout: micronaut-projects/micronaut-core#13110. It fixes the root cause of the dependency resolution failure on micronaut-projects/micronaut-control-panel#659.

## Problem

a757a88d pinned jackson-core in `cache-infinispan` with `strictly('2.21.4')` to get rid of the 2.21.3 (GHSA-r7wm-3cxj-wff9) that protostream 6.0.9 brings in. The strict version is published in the Gradle module metadata of 6.1.1:

```json
"dependencyConstraints": [{
  "group": "com.fasterxml.jackson.core", "module": "jackson-core",
  "version": { "strictly": "2.21.4", "requires": "2.21.4" },
  "reason": "2.21.3 is affected by GHSA-r7wm-3cxj-wff9"
}]
```

A `strictly` version rejects every other version, including newer ones. So a Gradle consumer that has cache-infinispan 6.1.1 plus anything requiring a higher jackson-core fails to resolve. micronaut-control-panel has failed this way on `2.2.x` since it moved to cache 6.1.1:

```
Could not resolve com.fasterxml.jackson.core:jackson-core:{strictly 2.21.4}.
  Required by: project ':micronaut-control-panel-ui' > io.micronaut.cache:micronaut-cache-infinispan:6.1.1
  > Component is the target of multiple version constraints with conflicting requirements:
    2.18.9 - directly in 'io.micronaut.objectstorage:micronaut-object-storage-gcp:3.1.0'
    2.21.4 - directly in 'io.micronaut.cache:micronaut-cache-infinispan:6.1.1'
    2.22.1 - transitively via 'io.micronaut.objectstorage:micronaut-object-storage-azure:3.1.0'
```

(micronaut-kafka 6.1.0 and the Micronaut platform 5.1.4 require 2.22.1 and 2.21.5, so they conflict with it too.)

## Fix

Keep the constraint but drop `strictly`. A plain constraint still lifts protostream's 2.21.3 to 2.21.4, and consumers can now resolve a newer jackson-core.

The published `module.json` now contains `"version": { "requires": "2.21.4" }`.

## Merge-up to 6.2.x

6.2.x doesn't have a757a88d yet. micronaut-projects/micronaut-cache#1064 fixes the same audit finding there with a plain `api(libs.jackson.core)` constraint (2.22.2). When 6.1.x is merged up, keep #1064's constraint and drop this one.

A 6.1.2 release with this change would let control-panel and other consumers remove their workaround (micronaut-projects/micronaut-control-panel#661).

## Verification

- `./gradlew :micronaut-cache-infinispan:dependencyInsight --dependency com.fasterxml.jackson.core:jackson-core --configuration runtimeClasspath`: `jackson-core:2.21.3 -> 2.21.4`
- `:micronaut-cache-infinispan:generateMetadataFileForMavenPublication`: `requires 2.21.4`, no `strictly`
- `./gradlew :micronaut-cache-infinispan:check`: passes (16 tests, 0 failures; `checkPom` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

